### PR TITLE
cancro: camerawrapper: fix hdr behaivour

### DIFF
--- a/camera/CameraWrapper.cpp
+++ b/camera/CameraWrapper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015, The Android Open Source Project
+ * Copyright (C) 2015, The CyanogenMod Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ static android::Mutex gCameraWrapperLock;
 static camera_module_t *gVendorModule = 0;
 
 static char **fixed_set_params = NULL;
+static char KEY_QC_MORPHO_HDR[] = "morpho-hdr";
 
 static int camera_device_open(const hw_module_t *module, const char *name,
         hw_device_t **device);
@@ -54,7 +55,7 @@ camera_module_t HAL_MODULE_INFO_SYM = {
          .hal_api_version = HARDWARE_HAL_API_VERSION,
          .id = CAMERA_HARDWARE_MODULE_ID,
          .name = "Cancro Camera Wrapper",
-         .author = "The Android Open Source Project",
+         .author = "The CyanogenMod Project",
          .methods = &camera_module_methods,
          .dso = NULL, /* remove compilation warnings */
          .reserved = {0}, /* remove compilation warnings */
@@ -119,6 +120,8 @@ static char *camera_fixup_getparams(int id __attribute__((unused)),
 
 static char *camera_fixup_setparams(int id, const char *settings)
 {
+    bool XiaomiHDR = false;
+
     android::CameraParameters params;
     params.unflatten(android::String8(settings));
 
@@ -128,6 +131,16 @@ static char *camera_fixup_setparams(int id, const char *settings)
 #endif
 
     params.set(android::CameraParameters::KEY_VIDEO_STABILIZATION, "false");
+
+    if (params.get(android::CameraParameters::KEY_SCENE_MODE)) {
+        XiaomiHDR = (!strcmp(params.get(android::CameraParameters::KEY_SCENE_MODE), "hdr"));
+    }
+    if (XiaomiHDR) {
+        params.set(KEY_QC_MORPHO_HDR, "true");
+        params.set(android::CameraParameters::KEY_FLASH_MODE, android::CameraParameters::FLASH_MODE_OFF);
+    } else {
+        params.set(KEY_QC_MORPHO_HDR, "false");
+    }
 
 #if !LOG_NDEBUG
     ALOGV("%s: fixed parameters:", __FUNCTION__);


### PR DESCRIPTION
fix HDR turning on flash and taking overexposed photos

Change-Id: I2c49f6a041ce789d45a75907d34371e307710718
Signed-off-by: jrizzoli joey@cyanogenmoditalia.it
